### PR TITLE
Repo org changed to gobetterfly.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2021 Xerpa
+Copyright (c) 2021 Betterfly
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule CleanArchitecture.MixProject do
       # These are the default files included in the package
       files: ~w(lib .formatter.exs mix.exs README* LICENSE* CHANGELOG*),
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/Xerpa/clean_architecture_ex"}
+      links: %{"GitHub" => "https://github.com/gobetterfly/clean_architecture_ex"}
     ]
   end
 


### PR DESCRIPTION
### What was Done?

We have changed to repo organization from Xerpa to gobetterfly.