### PR TITLE
Fix contract for array attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.1 (2022-09-21)
+
+* **[Contract]** Fix issue when contract has a field of the type array.
+
 ## 0.1.0 (2021-12-30)
 
 First release.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The package can be installed by adding `clean_architecture` to your list of depe
 ```elixir
 def deps do
   [
-    {:clean_architecture, "~> 0.1.0"}
+    {:clean_architecture, "~> 0.1.1"}
   ]
 end
 ```

--- a/lib/clean_architecture/contract.ex
+++ b/lib/clean_architecture/contract.ex
@@ -67,6 +67,8 @@ defmodule CleanArchitecture.Contract do
         end)
       end
 
+      defp get_input_changes(value), do: value
+
       defp put_input_changes_into_map(map, key, value) do
         case value do
           %Ecto.Changeset{} ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule CleanArchitecture.MixProject do
   def project do
     [
       app: :clean_architecture,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/clean_architecture/contract_test.exs
+++ b/test/clean_architecture/contract_test.exs
@@ -166,5 +166,10 @@ defmodule CleanArchitecture.ContractTest do
       assert ContractMock.validate_input(%{name: "Foo", nested_list: [%{name: "Bar", foo: "bar"}]}) ==
                {:ok, %{name: "Foo", nested_list: [%{name: "Bar"}]}}
     end
+
+    test "returns input changes with list os strings" do
+      assert ContractMock.validate_input(%{name: "Foo", list_of_strings: ["Bar"]}) ==
+               {:ok, %{name: "Foo", list_of_strings: ["Bar"]}}
+    end
   end
 end

--- a/test/support/contract_mock.ex
+++ b/test/support/contract_mock.ex
@@ -16,6 +16,7 @@ defmodule CleanArchitecture.Support.ContractMock do
     field(:name, :string)
     field(:last_name, :string)
     field(:other, :string)
+    field(:list_of_strings, {:array, :string})
 
     embeds_one(:nested, CleanArchitecture.Support.ContractMock)
     embeds_many(:nested_list, CleanArchitecture.Support.ContractMock)
@@ -27,7 +28,7 @@ defmodule CleanArchitecture.Support.ContractMock do
 
   def changeset(%__MODULE__{} = mock, %{} = attrs) do
     mock
-    |> cast(attrs, [:name, :last_name, :other])
+    |> cast(attrs, [:name, :last_name, :other, :list_of_strings])
     |> cast_embed(:nested, required: false)
     |> cast_embed(:nested_list, required: false)
     |> validate_required([:name])


### PR DESCRIPTION
### What have been done?

Fix issue when contract has a field of the type array.

### How to test

1. Create a new contract having a field of type `{:array, :string}`
2. Try to use the `validate_input` function, it should work.

